### PR TITLE
Reduce Docker image size with Alpine-based Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:onbuild
+FROM sdurrheimer/alpine-golang-make-onbuild
 MAINTAINER Kris Budde <Kris.Budde@gmail.com>
 EXPOSE 9090

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+VERSION  := 0.10.0
+TARGET   := rabbitmq_exporter
+
+include Makefile.COMMON

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -1,0 +1,131 @@
+# Copyright 2015 The Prometheus Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# THE AUTHORITATIVE VERSION OF THIS MAKEFILE LIVES IN:
+#
+#   https://github.com/prometheus/utils
+#
+# PLEASE MAKE ANY CHANGES THERE AND PROPAGATE THEM TO ALL PROMETHEUS
+# REPOSITORIES THAT ARE USING THIS MAKEFILE.
+#
+# This file provides common Makefile infrastructure for several Prometheus
+# components. This includes make tasks for downloading Go, setting up a
+# self-contained build environment, fetching Go dependencies, building
+# binaries, running tests, and doing release management. This file is intended
+# to be included from a project's Makefile, which needs to define the following
+# variables, at a minimum:
+#
+# * VERSION - The current version of the project in question.
+# * TARGET  - The desired name of the built binary.
+#
+# Many of the variables defined below are defined conditionally (using '?'),
+# which allows the project's main Makefile to override any of these settings, if
+# needed. See also:
+#
+# https://www.gnu.org/software/make/manual/html_node/Flavors.html#Flavors.
+#
+# The including Makefile may define any number of extra targets that are
+# specific to that project.
+
+VERSION ?= $(error VERSION not set in including Makefile)
+TARGET  ?= $(error TARGET not set in including Makefile)
+
+SRC    ?= $(shell find . -type f -name "*.go" ! -path "./.build/*")
+GOOS   ?= $(shell uname | tr A-Z a-z)
+GOARCH ?= $(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
+
+GO_VERSION ?= 1.5.3
+GOPATH     ?= $(CURDIR)/.build/gopath
+ROOTPKG    ?= github.com/prometheus/$(TARGET)
+SELFLINK   ?= $(GOPATH)/src/$(ROOTPKG)
+
+# Check for the correct version of go in the path. If we find it, use it.
+# Otherwise, prepare to build go locally.
+ifeq ($(shell command -v "go" >/dev/null && go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/'), $(GO_VERSION))
+	GOCC   ?= $(shell command -v "go")
+	GOFMT  ?= $(shell command -v "gofmt")
+	GO     ?= GOPATH=$(GOPATH) $(GOCC)
+else
+	GOURL  ?= https://golang.org/dl
+	GOPKG  ?= go$(GO_VERSION).$(GOOS)-$(GOARCH).tar.gz
+	GOROOT ?= $(CURDIR)/.build/go$(GO_VERSION)
+	GOCC   ?= $(GOROOT)/bin/go
+	GOFMT  ?= $(GOROOT)/bin/gofmt
+	GO     ?= GOPATH=$(GOPATH) GOROOT=$(GOROOT) $(GOCC)
+endif
+
+# Use vendored dependencies if available. Otherwise try to download them.
+ifneq (,$(wildcard vendor))
+	DEPENDENCIES := $(shell find vendor/ -type f -iname '*.go')
+	GO           := GO15VENDOREXPERIMENT=1 $(GO)
+else
+	DEPENDENCIES := dependencies-stamp
+endif
+
+# Never honor GOBIN, should it be set at all.
+unexport GOBIN
+
+SUFFIX   ?= $(GOOS)-$(GOARCH)
+BINARY   ?= $(TARGET)
+ARCHIVE  ?= $(TARGET)-$(VERSION).$(SUFFIX).tar.gz
+
+default: $(BINARY)
+
+$(BINARY): $(GOCC) $(SRC) $(DEPENDENCIES) Makefile Makefile.COMMON | $(SELFLINK)
+	cd $(SELFLINK) && $(GO) build $(GOFLAGS) -o $@
+
+.PHONY: archive
+archive: $(ARCHIVE)
+
+$(ARCHIVE): $(BINARY)
+	tar -czf $@ $<
+
+.PHONY: tag
+tag:
+	git tag $(VERSION)
+	git push --tags
+
+.PHONY: test
+test: $(GOCC) $(DEPENDENCIES) | $(SELFLINK)
+	cd $(SELFLINK) && $(GO) test $$($(GO) list ./... | grep -v /vendor/)
+
+.PHONY: format
+format: $(GOCC)
+	find . -iname '*.go' | egrep -v "^\./\.build|./generated|\./vendor|\.(l|y)\.go" | xargs -n1 $(GOFMT) -w -s=true
+
+.PHONY: clean
+clean:
+	rm -rf $(BINARY) $(ARCHIVE) .build *-stamp
+
+
+
+$(GOCC):
+	@echo Go version $(GO_VERSION) required but not found in PATH.
+	@echo About to download and install go$(GO_VERSION) to $(GOROOT)
+	@echo Abort now if you want to manually install it system-wide instead.
+	@echo
+	@sleep 5
+	mkdir -p .build
+	# The archive contains a single directory called 'go/'.
+	curl -L $(GOURL)/$(GOPKG) | tar -C .build -xzf -
+	rm -rf $(GOROOT)
+	mv .build/go $(GOROOT)
+
+$(SELFLINK):
+	mkdir -p $(dir $@)
+	ln -s $(CURDIR) $@
+
+# Download dependencies if project doesn't vendor them.
+dependencies-stamp: $(GOCC) $(SRC) | $(SELFLINK)
+	$(GO) get -d
+	touch $@


### PR DESCRIPTION
This PR updates the Dockerfile to use the Alpine Linux base image used by some of the official Prometheus services, [such as the statsd exporter](https://github.com/prometheus/statsd_exporter/blob/e9eb193ff92df215c822105e823f102f8d1660f6/Dockerfile#L1).

The result is dramatically smaller Docker image sizes.