### PR TITLE
Clean up connections

### DIFF
--- a/rabbitClient.go
+++ b/rabbitClient.go
@@ -29,13 +29,13 @@ func getMetrics(config rabbitExporterConfig, endpoint string) io.ReadCloser {
 func getQueueMap(config rabbitExporterConfig) map[string]MetricMap {
 	metric := getMetrics(config, "queues")
 	qm := MakeQueueMap(json.NewDecoder(metric))
-	defer metric.Close()
+	metric.Close()
 	return qm
 }
 
 func getOverviewMap(config rabbitExporterConfig) MetricMap {
 	metric := getMetrics(config, "overview")
 	overview := MakeMap(json.NewDecoder(metric))
-	defer metric.Close()
+	metric.Close()
 	return overview
 }


### PR DESCRIPTION
The connections was not closed. This might cause problems when running the rabbitmq management with an reverse-proxy.
See https://golang.org/pkg/net/http/ - "The client must close the response body when finished with it."
