### PR TITLE
Add metric 'rabbitmq_up'

### DIFF
--- a/exporter_test.go
+++ b/exporter_test.go
@@ -57,4 +57,5 @@ func TestWholeApp(t *testing.T) {
 	expectSubstring(t, body, `rabbitmq_queue_memory{queue="myQueue4",vhost="vhost4"} 13912`)
 	expectSubstring(t, body, `rabbitmq_queue_messages_published_total{queue="myQueue1",vhost="/"} 6`)
 	expectSubstring(t, body, `rabbitmq_queue_disk_writes{queue="myQueue1",vhost="/"} 6`)
+	expectSubstring(t, body, `rabbitmq_up 1`)
 }

--- a/metrics.go
+++ b/metrics.go
@@ -9,6 +9,8 @@ const (
 var (
 	queueLabelNames = []string{"vhost", "queue"}
 
+	upMetricDescription = newMetric("up", "Was the last scrape of rabbitmq successful.")
+
 	overviewMetricDescription = map[string]prometheus.Gauge{
 		"object_totals.channels":    newMetric("channelsTotal", "Total number of open channels."),
 		"object_totals.connections": newMetric("connectionsTotal", "Total number of open connections."),

--- a/rabbitClient_test.go
+++ b/rabbitClient_test.go
@@ -31,7 +31,7 @@ func TestOverview(t *testing.T) {
 		RabbitURL: server.URL,
 	}
 
-	overview := getOverviewMap(*config)
+	overview, _ := getOverviewMap(*config)
 
 	expect(t, len(overview), 2)
 	expect(t, overview["float1"], 1.23456789101112)
@@ -45,7 +45,7 @@ func TestOverview(t *testing.T) {
 		RabbitURL: errorServer.URL,
 	}
 
-	overview = getOverviewMap(*config)
+	overview, _ = getOverviewMap(*config)
 
 	expect(t, len(overview), 0)
 }
@@ -59,7 +59,7 @@ func TestQueues(t *testing.T) {
 		RabbitURL: server.URL,
 	}
 
-	queues := getQueueInfo(*config)
+	queues, _ := getQueueInfo(*config)
 	expect(t, len(queues), 2)
 	expect(t, queues[0].name, "Queue1")
 	expect(t, queues[0].vhost, "")
@@ -80,7 +80,7 @@ func TestQueues(t *testing.T) {
 		RabbitURL: errorServer.URL,
 	}
 
-	queues = getQueueInfo(*config)
+	queues, _ = getQueueInfo(*config)
 
 	expect(t, len(queues), 0)
 }


### PR DESCRIPTION
The new metric exposes whether the last scrape of RabbitMQ was
successful. It is inspired by the haproxy_exporter which exposes the
metric `haproxy_up`.
The value of `rabbitmq_up` is either `1` or `0`. It can be used to
determine whether the RabbitMQ process being scraped is up-and-running.

In order to be able to set the metric, some functions have been
rewritten to return error values instead of using callbacks.