### PR TITLE
Add feature to skip queues by regexp

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ var (
 		OutputFormat:       "TTY", //JSON
 		CAFile:             "ca.pem",
 		InsecureSkipVerify: false,
+		SkipQueues:         "^$",
 	}
 )
 
@@ -28,6 +29,7 @@ type rabbitExporterConfig struct {
 	OutputFormat       string
 	CAFile             string
 	InsecureSkipVerify bool
+	SkipQueues         string
 }
 
 func initConfig() {
@@ -62,5 +64,9 @@ func initConfig() {
 	}
 	if insecureSkipVerify := os.Getenv("SKIPVERIFY"); insecureSkipVerify == "true" || insecureSkipVerify == "1" {
 		config.InsecureSkipVerify = true
+	}
+
+	if SkipQueues := os.Getenv("SKIP_QUEUES"); SkipQueues != "" {
+		config.SkipQueues = SkipQueues
 	}
 }


### PR DESCRIPTION
Add feature to skip queues by regexp. We are using RPC queues and our Prometheus instances are just crashing due to `infinity` numbers of time series. This solves by skipping RPC to export.

rabbitmq-env:
```
PUBLISH_PORT=9301
LOG_LEVEL=warning
SKIP_QUEUES=^amq\.gen-
```
![screen shot 2016-11-15 at 12 19 09](https://cloud.githubusercontent.com/assets/3352707/20301856/c130a50c-ab2d-11e6-965a-256b18183e45.png)

@kbudde 