### PR TITLE
Move regexp check outside if for queueMetricsCounter

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -69,13 +69,13 @@ func (e *exporter) fetchRabbit(ch chan<- prometheus.Metric) {
 	}
 	for key, countvec := range e.queueMetricsCounter {
 		for _, queue := range rabbitMqQueueData {
-			if value, ok := queue.metrics[key]; ok {
-				if match, _ := regexp.MatchString(config.SkipQueues, strings.ToLower(queue.name)); !match {
+			if match, _ := regexp.MatchString(config.SkipQueues, strings.ToLower(queue.name)); !match {
+				if value, ok := queue.metrics[key]; ok {
 					log.WithFields(log.Fields{"vhost": queue.vhost, "queue": queue.name, "key": key, "value": value}).Debug("Set queue metric for key")
 					ch <- prometheus.MustNewConstMetric(countvec, prometheus.CounterValue, value, queue.vhost, queue.name)
+				} else {
+					ch <- prometheus.MustNewConstMetric(countvec, prometheus.CounterValue, 0, queue.vhost, queue.name)
 				}
-			} else {
-				ch <- prometheus.MustNewConstMetric(countvec, prometheus.CounterValue, 0, queue.vhost, queue.name)
 			}
 		}
 	}


### PR DESCRIPTION
Move regexp check outside if for queueMetricsCounter. This have to be checked before that `if`, because it has else statement. 

Without this fix, everything is OK, except series with 0 values ;-)

```
rabbitmq_queue_messages_confirmed_total{queue="amq.gen-D9-tLC08DhHR7LpVvS46yw",vhost="/"} 0
rabbitmq_queue_messages_confirmed_total{queue="amq.gen-DblmSkBVZp8Gl4dwKYwPEg",vhost="/"} 0
rabbitmq_queue_messages_confirmed_total{queue="amq.gen-Dh5bABAqvPXJjt4vZYc83w",vhost="/"} 0
rabbitmq_queue_messages_confirmed_total{queue="amq.gen-EaFpWVDuLXjKQTKIMYUWTg",vhost="/"} 0
rabbitmq_queue_messages_confirmed_total{queue="amq.gen-Eo3QPH3g7xVM3Apmr3Qmyw",vhost="/"} 0
rabbitmq_queue_messages_confirmed_total{queue="amq.gen-EpOFQJSPvIMFA5E687J8ew",vhost="/"} 0
rabbitmq_queue_messages_confirmed_total{queue="amq.gen-Ex5ih19mEglqSCNu71eLAg",vhost="/"} 0
rabbitmq_queue_messages_confirmed_total{queue="amq.gen-FKv3q23dx4Irnn2mY_YKxA",vhost="/"} 0
rabbitmq_queue_messages_confirmed_total{queue="amq.gen-FukZIkV1eZTp9J1Rsse49g",vhost="/"} 0
rabbitmq_queue_messages_confirmed_total{queue="amq.gen-HgkmJEjueYEbh0oMehPD3g",vhost="/"} 0
```

@kbudde 