### PR TITLE
Don't ask for sorted results from RabbitMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,25 @@ Settings:
 * SKIPVERIFY:      false or 0, true or 1 // will skip hostname/certificate check at all
 * INCLUDE_QUEUES:  ".*", // regex, matching queue names are exported
 * SKIP_QUEUES:     "^$", // regex, matching queue names are not exported (useful for short-lived rpc queues). First performed INCLUDE, after SKIP
+* RABBIT_CAPABILITIES: "", // comma-separated list of extended scraping capabilities supported by the target RabbitMQ server
 
 Example
 
     OUTPUT_FORMAT=JSON PUBLISH_PORT=9099 ./rabbitmq_exporter
+
+#### Extended RabbitMQ capabilities
+
+Newer version of RabbitMQ can provide some features that reduce
+overhead imposed by scraping the data needed by this exporter. The
+following capabilities are currently supported in
+`RABBIT_CAPABILITIES` env var:
+
+* `no_sort`: By default RabbitMQ management plugin sorts results using
+  the default sort order of vhost/name. This sorting overhead can be
+  avoided by passing empty sort argument (`?sort=`) to RabbitMQ
+  starting from version 3.6.8. This option can be safely enabled on
+  earlier 3.6.X versions, but it'll not give any performance
+  improvements. And it's incompatible with 3.4.X and 3.5.X.
 
 ### Metrics
 

--- a/rabbitClient.go
+++ b/rabbitClient.go
@@ -41,7 +41,13 @@ func initClient() {
 }
 
 func loadMetrics(config rabbitExporterConfig, endpoint string) (*json.Decoder, error) {
-	req, err := http.NewRequest("GET", config.RabbitURL+"/api/"+endpoint, nil)
+	var args string
+	enabled, exists := config.RabbitCapabilities[rabbitCapNoSort]
+	if enabled && exists {
+		args = "?sort="
+	}
+
+	req, err := http.NewRequest("GET", config.RabbitURL+"/api/"+endpoint+args, nil)
 	req.SetBasicAuth(config.RabbitUsername, config.RabbitPassword)
 
 	resp, err := client.Do(req)


### PR DESCRIPTION
E.g. for 10000 queues performing the sort using the default sorting
order costs ~0.3 second on my machine.

Now that https://github.com/rabbitmq/rabbitmq-management/pull/369 is
merged we can avoid this cost. This change is backward compatible, for older versions of RabbitMQ adding empty `sort` parameter will result in using the default sort order(`vhost`, `name`)