### PR TITLE
Log and return error on request construction failure.

### DIFF
--- a/rabbitClient.go
+++ b/rabbitClient.go
@@ -46,6 +46,11 @@ func loadMetrics(config rabbitExporterConfig, endpoint string) (RabbitReply, err
 	}
 
 	req, err := http.NewRequest("GET", config.RabbitURL+"/api/"+endpoint+args, nil)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err, "host": config.RabbitURL}).Error("Error while constructing rabbitHost request")
+		return nil, errors.New("Error while constructing rabbitHost request")
+	}
+
 	req.SetBasicAuth(config.RabbitUsername, config.RabbitPassword)
 	req.Header.Add("Accept", acceptContentType(config))
 


### PR DESCRIPTION
This could happen if the configuration is broken and contains
invalid characters. In that case, the `err` parameter is
silently ignored.