### PR TITLE
added option to set listening host/ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ RABBIT_PASSWORD | guest | password for rabbitMQ management plugin
 RABBIT_USER_FILE| | location of file with username (useful for docker secrets)
 RABBIT_PASSWORD_FILE | | location of file with password (useful for docker secrets)
 PUBLISH_PORT | 9090 | Listening port for the exporter
+PUBLISH_ADDR | "" | Listening host/IP for the exporter
 OUTPUT_FORMAT | TTY | Log ouput format. TTY and JSON are suported
 LOG_LEVEL | info | log level. possible values: "debug", "info", "warning", "error", "fatal", or "panic"
 CAFILE | ca.pem | path to root certificate for access management plugin. Just needed if self signed certificate is used. Will be ignored if the file does not exist

--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ var (
 		RabbitUsername:     "guest",
 		RabbitPassword:     "guest",
 		PublishPort:        "9090",
+		PublishAddr:        "",
 		OutputFormat:       "TTY", //JSON
 		CAFile:             "ca.pem",
 		InsecureSkipVerify: false,
@@ -30,6 +31,7 @@ type rabbitExporterConfig struct {
 	RabbitUsername     string
 	RabbitPassword     string
 	PublishPort        string
+	PublishAddr        string
 	OutputFormat       string
 	CAFile             string
 	InsecureSkipVerify bool
@@ -96,6 +98,11 @@ func initConfig() {
 		}
 
 	}
+
+	if addr := os.Getenv("PUBLISH_ADDR"); addr != "" {
+		config.PublishAddr = addr
+	}
+
 	if output := os.Getenv("OUTPUT_FORMAT"); output != "" {
 		config.OutputFormat = output
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -80,6 +80,16 @@ func TestEnvironmentSettingPort(t *testing.T) {
 	}
 }
 
+func TestEnvironmentSettingAddr(t *testing.T) {
+	newValue := "localhost"
+	os.Setenv("PUBLISH_ADDR", newValue)
+	defer os.Unsetenv("PUBLISH_ADDR")
+	initConfig()
+	if config.PublishAddr != newValue {
+		t.Errorf("Expected config.PUBLISH_ADDR to be modified. Found=%v, expected=%v", config.PublishAddr, newValue)
+	}
+}
+
 func TestEnvironmentSettingFormat(t *testing.T) {
 	newValue := "json"
 	os.Setenv("OUTPUT_FORMAT", newValue)
@@ -97,6 +107,16 @@ func TestConfig_Port(t *testing.T) {
 	initConfig()
 	if config.PublishPort != port {
 		t.Errorf("Invalid Portnumber. It should not be set. expected=%v,got=%v", port, config.PublishPort)
+	}
+}
+
+func TestConfig_Addr(t *testing.T) {
+	addr := config.PublishAddr
+	os.Setenv("PUBLISH_ADDR", "")
+	defer os.Unsetenv("PUBLISH_ADDR")
+	initConfig()
+	if config.PublishAddr != addr {
+		t.Errorf("Invalid Addrress. It should not be set. expected=%v,got=%v", addr, config.PublishAddr)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func main() {
 	}).Info("Starting RabbitMQ exporter")
 
 	log.WithFields(log.Fields{
+		"PUBLISH_ADDR":        config.PublishAddr,
 		"PUBLISH_PORT":        config.PublishPort,
 		"RABBIT_URL":          config.RabbitURL,
 		"RABBIT_USER":         config.RabbitUsername,
@@ -58,7 +59,7 @@ func main() {
 		//		"RABBIT_PASSWORD": config.RABBIT_PASSWORD,
 	}).Info("Active Configuration")
 
-	log.Fatal(http.ListenAndServe(":"+config.PublishPort, nil))
+	log.Fatal(http.ListenAndServe(config.PublishAddr+":"+config.PublishPort, nil))
 }
 
 func getLogLevel() log.Level {


### PR DESCRIPTION
added an option to define an IP or host on which the publisher should listen on. this should be fully backwards compatible.