### PR TITLE
INCLUDE and SKIP Vhost filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ OUTPUT_FORMAT | TTY | Log ouput format. TTY and JSON are suported
 LOG_LEVEL | info | log level. possible values: "debug", "info", "warning", "error", "fatal", or "panic"
 CAFILE | ca.pem | path to root certificate for access management plugin. Just needed if self signed certificate is used. Will be ignored if the file does not exist
 SKIPVERIFY | false | true/0 will ignore certificate errors of the management plugin
+SKIP_VHOST | ^$ |regex, matching vhost names are not exported. First performs INCLUDE_VHOST, then SKIP_VHOST
 INCLUDE_VHOST | .* | reqgex vhost filter. Only queues in matching vhosts are exported
 INCLUDE_QUEUES | .* | reqgex queue filter. just matching names are exported
 SKIP_QUEUES | ^$ |regex, matching queue names are not exported (useful for short-lived rpc queues). First performed INCLUDE, after SKIP

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Data is scraped by [prometheus](https://prometheus.io).
 # Breaking change -> 1.0.0
 
 Default Port is going to change in the future. New Port is 9419.
-Configuration below is using the recommended configuration with the new port. 
+Configuration below is using the recommended configuration with the new port.
 
 If you are still using the old default port 9090 consider overriding it with the new default.
 https://github.com/kbudde/rabbitmq_exporter/issues/53
@@ -44,12 +44,13 @@ RABBIT_USER | guest | username for rabbitMQ management plugin
 RABBIT_PASSWORD | guest | password for rabbitMQ management plugin
 RABBIT_USER_FILE| | location of file with username (useful for docker secrets)
 RABBIT_PASSWORD_FILE | | location of file with password (useful for docker secrets)
-PUBLISH_PORT | 9090 | Listening port for the exporter 
+PUBLISH_PORT | 9090 | Listening port for the exporter
 PUBLISH_ADDR | "" | Listening host/IP for the exporter
 OUTPUT_FORMAT | TTY | Log ouput format. TTY and JSON are suported
 LOG_LEVEL | info | log level. possible values: "debug", "info", "warning", "error", "fatal", or "panic"
 CAFILE | ca.pem | path to root certificate for access management plugin. Just needed if self signed certificate is used. Will be ignored if the file does not exist
 SKIPVERIFY | false | true/0 will ignore certificate errors of the management plugin
+INCLUDE_VHOST | .* | reqgex vhost filter. Only queues in matching vhosts are exported
 INCLUDE_QUEUES | .* | reqgex queue filter. just matching names are exported
 SKIP_QUEUES | ^$ |regex, matching queue names are not exported (useful for short-lived rpc queues). First performed INCLUDE, after SKIP
 RABBIT_CAPABILITIES | | comma-separated list of extended scraping capabilities supported by the target RabbitMQ server

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ var (
 		InsecureSkipVerify: false,
 		SkipQueues:         regexp.MustCompile("^$"),
 		IncludeQueues:      regexp.MustCompile(".*"),
+		SkipVHost:          regexp.MustCompile("^$"),
 		IncludeVHost:       regexp.MustCompile(".*"),
 		RabbitCapabilities: make(rabbitCapabilitySet),
 		EnabledExporters:   []string{"exchange", "node", "overview", "queue"},
@@ -40,6 +41,7 @@ type rabbitExporterConfig struct {
 	InsecureSkipVerify bool
 	SkipQueues         *regexp.Regexp
 	IncludeQueues      *regexp.Regexp
+	SkipVHost          *regexp.Regexp
 	IncludeVHost       *regexp.Regexp
 	RabbitCapabilities rabbitCapabilitySet
 	EnabledExporters   []string
@@ -129,6 +131,10 @@ func initConfig() {
 
 	if IncludeQueues := os.Getenv("INCLUDE_QUEUES"); IncludeQueues != "" {
 		config.IncludeQueues = regexp.MustCompile(IncludeQueues)
+	}
+
+	if SkipVHost := os.Getenv("SKIP_VHOST"); SkipVHost != "" {
+		config.SkipVHost = regexp.MustCompile(SkipVHost)
 	}
 
 	if IncludeVHost := os.Getenv("INCLUDE_VHOST"); IncludeVHost != "" {

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ var (
 		InsecureSkipVerify: false,
 		SkipQueues:         regexp.MustCompile("^$"),
 		IncludeQueues:      regexp.MustCompile(".*"),
+		IncludeVHost:       regexp.MustCompile(".*"),
 		RabbitCapabilities: make(rabbitCapabilitySet),
 		EnabledExporters:   []string{"exchange", "node", "overview", "queue"},
 		Timeout:            30,
@@ -39,6 +40,7 @@ type rabbitExporterConfig struct {
 	InsecureSkipVerify bool
 	SkipQueues         *regexp.Regexp
 	IncludeQueues      *regexp.Regexp
+	IncludeVHost       *regexp.Regexp
 	RabbitCapabilities rabbitCapabilitySet
 	EnabledExporters   []string
 	Timeout            int
@@ -127,6 +129,10 @@ func initConfig() {
 
 	if IncludeQueues := os.Getenv("INCLUDE_QUEUES"); IncludeQueues != "" {
 		config.IncludeQueues = regexp.MustCompile(IncludeQueues)
+	}
+
+	if IncludeVHost := os.Getenv("INCLUDE_VHOST"); IncludeVHost != "" {
+		config.IncludeVHost = regexp.MustCompile(IncludeVHost)
 	}
 
 	if rawCapabilities := os.Getenv("RABBIT_CAPABILITIES"); rawCapabilities != "" {

--- a/exporter_queue.go
+++ b/exporter_queue.go
@@ -80,13 +80,15 @@ func (e exporterQueue) Collect(ch chan<- prometheus.Metric) error {
 	for key, gaugevec := range e.queueMetricsGauge {
 		for _, queue := range rabbitMqQueueData {
 			qname := queue.labels["name"]
+			vname := queue.labels["vhost"]
 			if value, ok := queue.metrics[key]; ok {
 
-				if matchInclude := config.IncludeQueues.MatchString(strings.ToLower(qname)); matchInclude {
-					if matchSkip := config.SkipQueues.MatchString(strings.ToLower(qname)); !matchSkip {
-
-						// log.WithFields(log.Fields{"vhost": queue.vhost, "queue": queue.name, "key": key, "value": value}).Debug("Set queue metric for key")
-						gaugevec.WithLabelValues(queue.labels["vhost"], queue.labels["name"], queue.labels["durable"], queue.labels["policy"]).Set(value)
+				if matchVhost := config.IncludeVHost.MatchString(strings.ToLower(vname)); matchVhost {
+					if matchInclude := config.IncludeQueues.MatchString(strings.ToLower(qname)); matchInclude {
+						if matchSkip := config.SkipQueues.MatchString(strings.ToLower(qname)); !matchSkip {
+							log.WithFields(log.Fields{"vhost": queue.labels["vhost"], "queue": queue.labels["name"], "key": key, "value": value}).Info("Set queue metric for key")
+							gaugevec.WithLabelValues(queue.labels["vhost"], queue.labels["name"], queue.labels["durable"], queue.labels["policy"]).Set(value)
+						}
 					}
 				}
 			}
@@ -96,13 +98,17 @@ func (e exporterQueue) Collect(ch chan<- prometheus.Metric) error {
 	for key, countvec := range e.queueMetricsCounter {
 		for _, queue := range rabbitMqQueueData {
 			qname := queue.labels["name"]
-			if matchInclude := config.IncludeQueues.MatchString(strings.ToLower(qname)); matchInclude {
-				if matchSkip := config.SkipQueues.MatchString(strings.ToLower(qname)); !matchSkip {
+			vname := queue.labels["vhost"]
 
-					if value, ok := queue.metrics[key]; ok {
-						ch <- prometheus.MustNewConstMetric(countvec, prometheus.CounterValue, value, queue.labels["vhost"], queue.labels["name"], queue.labels["durable"], queue.labels["policy"])
-					} else {
-						ch <- prometheus.MustNewConstMetric(countvec, prometheus.CounterValue, 0, queue.labels["vhost"], queue.labels["name"], queue.labels["durable"], queue.labels["policy"])
+			if matchVhost := config.IncludeVHost.MatchString(strings.ToLower(vname)); matchVhost {
+				if matchInclude := config.IncludeQueues.MatchString(strings.ToLower(qname)); matchInclude {
+					if matchSkip := config.SkipQueues.MatchString(strings.ToLower(qname)); !matchSkip {
+
+						if value, ok := queue.metrics[key]; ok {
+							ch <- prometheus.MustNewConstMetric(countvec, prometheus.CounterValue, value, queue.labels["vhost"], queue.labels["name"], queue.labels["durable"], queue.labels["policy"])
+						} else {
+							ch <- prometheus.MustNewConstMetric(countvec, prometheus.CounterValue, 0, queue.labels["vhost"], queue.labels["name"], queue.labels["durable"], queue.labels["policy"])
+						}
 					}
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func main() {
 		"SKIPVERIFY":          config.InsecureSkipVerify,
 		"SKIP_QUEUES":         config.SkipQueues.String(),
 		"INCLUDE_QUEUES":      config.IncludeQueues,
+		"INCLUDE_VHOST":       config.IncludeVHost,
 		"RABBIT_TIMEOUT":      config.Timeout,
 		//		"RABBIT_PASSWORD": config.RABBIT_PASSWORD,
 	}).Info("Active Configuration")

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func main() {
 		"SKIPVERIFY":          config.InsecureSkipVerify,
 		"SKIP_QUEUES":         config.SkipQueues.String(),
 		"INCLUDE_QUEUES":      config.IncludeQueues,
+		"SKIP_VHOST":          config.SkipVHost.String(),
 		"INCLUDE_VHOST":       config.IncludeVHost,
 		"RABBIT_TIMEOUT":      config.Timeout,
 		//		"RABBIT_PASSWORD": config.RABBIT_PASSWORD,


### PR DESCRIPTION
Allow users to specify VHOSTS for filtering.

Note: Only applies to queues at the moment, so can either be merged as is, or request additional work to filter on other metrics collections too