### PR TITLE
Change Exchanges docs to 'Counter' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ metric | description
 |queue_messages_redelivered_total|Count of subset of messages in deliver_get which had the redelivered flag set.|
 |queue_messages_returned_total|Count of messages returned to publisher as unroutable.|
 
-### Exchanges - Gauge
+### Exchanges - Counter
 
 Labels: vhost, exchange
 


### PR DESCRIPTION
Please correct me if I'm wrong, but the README appears to be incorrectly labelling Exchange metric types as `Gauge`, when they are actually `Counter`.