### PR TITLE
added config option for max number of queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ SKIP_QUEUES | ^$ |regex, matching queue names are not exported (useful for short
 RABBIT_CAPABILITIES | | comma-separated list of extended scraping capabilities supported by the target RabbitMQ server
 RABBIT_EXPORTERS | exchange,node,overview,queue | List of enabled modules. Just "connections" is not enabled by default
 RABBIT_TIMEOUT | 30 | timeout in seconds for retrieving data from management plugin.
-MAX_QUEUES | 5000 | max number of queues before we drop metrics
+MAX_QUEUES | 0 | max number of queues before we drop metrics (disabled if set to 0)
 
 Example and recommended settings:
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ SKIP_QUEUES | ^$ |regex, matching queue names are not exported (useful for short
 RABBIT_CAPABILITIES | | comma-separated list of extended scraping capabilities supported by the target RabbitMQ server
 RABBIT_EXPORTERS | exchange,node,overview,queue | List of enabled modules. Just "connections" is not enabled by default
 RABBIT_TIMEOUT | 30 | timeout in seconds for retrieving data from management plugin.
+MAX_QUEUES | 5000 | max number of queues before we drop metrics
 
 Example and recommended settings:
 

--- a/config.go
+++ b/config.go
@@ -25,7 +25,7 @@ var (
 		RabbitCapabilities: make(rabbitCapabilitySet),
 		EnabledExporters:   []string{"exchange", "node", "overview", "queue"},
 		Timeout:            30,
-		MaxQueues:          5000,
+		MaxQueues:          0,
 	}
 )
 

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ var (
 		RabbitCapabilities: make(rabbitCapabilitySet),
 		EnabledExporters:   []string{"exchange", "node", "overview", "queue"},
 		Timeout:            30,
+		MaxQueues:          5000,
 	}
 )
 
@@ -42,6 +43,7 @@ type rabbitExporterConfig struct {
 	RabbitCapabilities rabbitCapabilitySet
 	EnabledExporters   []string
 	Timeout            int
+	MaxQueues          int
 }
 
 type rabbitCapability string
@@ -143,6 +145,14 @@ func initConfig() {
 			panic(fmt.Errorf("timeout is not a number: %v", err))
 		}
 		config.Timeout = t
+	}
+
+	if maxQueues := os.Getenv("MAX_QUEUES"); maxQueues != "" {
+		m, err := strconv.Atoi(maxQueues)
+		if err != nil {
+			panic(fmt.Errorf("maxQueues is not a number: %v", err))
+		}
+		config.MaxQueues = m
 	}
 }
 

--- a/exporter_queue.go
+++ b/exporter_queue.go
@@ -70,6 +70,18 @@ func (e exporterQueue) Collect(ch chan<- prometheus.Metric) error {
 		gaugevec.Reset()
 	}
 
+	rabbitMqOverviewData, err := getMetricMap(config, "overview")
+
+	if err != nil {
+		return err
+	}
+
+	totalQueues := rabbitMqOverviewData["object_totals.queues"]
+
+	if int(totalQueues) > config.MaxQueues {
+		return nil
+	}
+
 	rabbitMqQueueData, err := getStatsInfo(config, "queues", queueLabelKeys)
 
 	if err != nil {

--- a/exporter_queue.go
+++ b/exporter_queue.go
@@ -70,16 +70,23 @@ func (e exporterQueue) Collect(ch chan<- prometheus.Metric) error {
 		gaugevec.Reset()
 	}
 
-	rabbitMqOverviewData, err := getMetricMap(config, "overview")
+	if config.MaxQueues > 0 {
+		// Get overview info to check total queues
+		rabbitMqOverviewData, err := getMetricMap(config, "overview")
 
-	if err != nil {
-		return err
-	}
+		if err != nil {
+			return err
+		}
 
-	totalQueues := rabbitMqOverviewData["object_totals.queues"]
+		totalQueues := rabbitMqOverviewData["object_totals.queues"]
 
-	if int(totalQueues) > config.MaxQueues {
-		return nil
+		if int(totalQueues) > config.MaxQueues {
+			log.WithFields(log.Fields{
+				"MaxQueues":   config.MaxQueues,
+				"TotalQueues": totalQueues,
+			}).Debug("MaxQueues exceeded.")
+			return nil
+		}
 	}
 
 	rabbitMqQueueData, err := getStatsInfo(config, "queues", queueLabelKeys)

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -162,6 +162,72 @@ func TestWholeAppInverted(t *testing.T) {
 	expectSubstring(t, body, `rabbitmq_connection_received_packets{node="rabbit@rmq-cluster-node-04",peer_host="172.31.0.130",user="rmq_oms",vhost="/"} 45416`)
 }
 
+func TestAppMaxQueues(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		if r.RequestURI == "/api/overview" {
+			fmt.Fprintln(w, overviewTestData)
+		} else if r.RequestURI == "/api/queues" {
+			fmt.Fprintln(w, queuesTestData)
+		} else if r.RequestURI == "/api/exchanges" {
+			fmt.Fprintln(w, exchangeAPIResponse)
+		} else if r.RequestURI == "/api/nodes" {
+			fmt.Fprintln(w, nodesAPIResponse)
+		} else if r.RequestURI == "/api/connections" {
+			fmt.Fprintln(w, connectionAPIResponse)
+		} else {
+			t.Errorf("Invalid request. URI=%v", r.RequestURI)
+			fmt.Fprintf(w, "Invalid request. URI=%v", r.RequestURI)
+		}
+
+	}))
+	defer server.Close()
+	os.Setenv("RABBIT_URL", server.URL)
+	os.Setenv("SKIP_QUEUES", "^.*3$")
+	os.Setenv("MAX_QUEUES", "3")
+	initConfig()
+
+	exporter := newExporter()
+	prometheus.MustRegister(exporter)
+	defer prometheus.Unregister(exporter)
+
+	req, _ := http.NewRequest("GET", "", nil)
+	w := httptest.NewRecorder()
+	prometheus.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("Home page didn't return %v", http.StatusOK)
+	}
+	body := w.Body.String()
+
+	expectSubstring(t, body, `rabbitmq_up 1`)
+
+	// overview
+	expectSubstring(t, body, `rabbitmq_exchangesTotal 8`)
+	expectSubstring(t, body, `rabbitmq_queuesTotal 4`)
+	expectSubstring(t, body, `rabbitmq_queue_messages_total 48`)
+	expectSubstring(t, body, `rabbitmq_queue_messages_ready_total 48`)
+	expectSubstring(t, body, `rabbitmq_queue_messages_unacknowledged_total 0`)
+
+	// node
+	expectSubstring(t, body, `rabbitmq_running{node="my-rabbit@5a00cd8fe2f4"} 1`)
+	expectSubstring(t, body, `rabbitmq_partitions{node="my-rabbit@5a00cd8fe2f4"} 4`)
+
+	// queue
+	dontExpectSubstring(t, body, `rabbitmq_queue_messages_ready{durable="true",policy="ha-2",queue="myQueue2",vhost="/"} 25`)
+	dontExpectSubstring(t, body, `rabbitmq_queue_memory{durable="true",policy="",queue="myQueue4",vhost="vhost4"} 13912`)
+	dontExpectSubstring(t, body, `rabbitmq_queue_messages_published_total{durable="true",policy="",queue="myQueue1",vhost="/"} 6`)
+	dontExpectSubstring(t, body, `rabbitmq_queue_disk_writes{durable="true",policy="",queue="myQueue1",vhost="/"} 6`)
+	dontExpectSubstring(t, body, `rabbitmq_queue_messages_delivered_total{durable="true",policy="",queue="myQueue1",vhost="/"} 0`)
+
+	// exchange
+	expectSubstring(t, body, `rabbitmq_exchange_messages_published_in_total{exchange="myExchange",vhost="/"} 5`)
+
+	// connection
+	dontExpectSubstring(t, body, `rabbitmq_connection_channels{node="rabbit@rmq-cluster-node-04",peer_host="172.31.0.130",user="rmq_oms",vhost="/"} 2`)
+	dontExpectSubstring(t, body, `rabbitmq_connection_received_packets{node="rabbit@rmq-cluster-node-04",peer_host="172.31.0.130",user="rmq_oms",vhost="/"} 45416`)
+}
+
 func TestRabbitError(t *testing.T) {
 	server := createTestserver(500, http.StatusText(500))
 	defer server.Close()

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 		"SKIP_QUEUES":         config.SkipQueues.String(),
 		"INCLUDE_QUEUES":      config.IncludeQueues,
 		"RABBIT_TIMEOUT":      config.Timeout,
+		"MAX_QUEUES":          config.MaxQueues,
 		//		"RABBIT_PASSWORD": config.RABBIT_PASSWORD,
 	}).Info("Active Configuration")
 


### PR DESCRIPTION
We have a customer that for some reason has 20k queues and it was bringing down our prometheus instance.  After some testing we found that once you go over 5k queues it tends to be less reliable.  Increasing timeout helps, but we decided the best course of action is to not support metrics qhen they have over 5k queues.

This PR add a configurable option `MaxQueues` that drops queue metrics when their total number of queues is greater than this number.  Current Default is 5k.  we really shouldn't have that many queues anyways.