### PR TITLE
Reset node stats

### DIFF
--- a/exporter_node.go
+++ b/exporter_node.go
@@ -49,6 +49,10 @@ func (e exporterNode) Collect(ch chan<- prometheus.Metric) error {
 		return err
 	}
 
+	for _, gauge := range e.nodeMetricsGauge {
+		gauge.Reset()
+	}
+
 	for key, gauge := range e.nodeMetricsGauge {
 		for _, node := range nodeData {
 			if value, ok := node.metrics[key]; ok {


### PR DESCRIPTION
We recently run into an issue where a single rabbitmq node left the cluster and never rejoined. The rabbitmq management API returned only two nodes, but the metrics endpoint still returned 3 nodes.

I assume resetting here similar to how its done in connections helps here, but I couldn't figure out how to test this. @kbudde any pointers how I could add a test?

