### PR TITLE
Fix: panic when max-length metrics are excluded

### DIFF
--- a/exporter_queue.go
+++ b/exporter_queue.go
@@ -215,11 +215,16 @@ func (e exporterQueue) Collect(ctx context.Context, ch chan<- prometheus.Metric)
 		}
 		e.stateMetric.WithLabelValues(append(labelValues, state)...).Set(1)
 
-		if f := collectLowerMetric("arguments.x-max-length", "effective_policy_definition.max-length", queue); f >= 0 {
-			limitsGaugeVec["max-length"].WithLabelValues(labelValues...).Set(f)
+		if _, ok := limitsGaugeVec["max-length"]; ok {
+			if f := collectLowerMetric("arguments.x-max-length", "effective_policy_definition.max-length", queue); f >= 0 {
+				limitsGaugeVec["max-length"].WithLabelValues(labelValues...).Set(f)
+			}
 		}
-		if f := collectLowerMetric("arguments.x-max-length-bytes", "effective_policy_definition.max-length-bytes", queue); f >= 0 {
-			limitsGaugeVec["max-length-bytes"].WithLabelValues(labelValues...).Set(f)
+
+		if _, ok := limitsGaugeVec["max-length-bytes"]; ok {
+			if f := collectLowerMetric("arguments.x-max-length-bytes", "effective_policy_definition.max-length-bytes", queue); f >= 0 {
+				limitsGaugeVec["max-length-bytes"].WithLabelValues(labelValues...).Set(f)
+			}
 		}
 
 	}


### PR DESCRIPTION

This PR fix an exporter crash when excluding max-length and max-length-bytes metrics. (limitsGaugeVec is an empty map in this case)

Step to reproduce : 
* Version : v1.0.0-RC13
* Set EXCLUDE_METRICS=max-length-bytes,max-length
* Scrape data

Panic output
```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7c19fd]

goroutine 25 [running]:
github.com/prometheus/client_golang/prometheus.(*GaugeVec).WithLabelValues(0x85cee0, {0xc001b111a0, 0x8cd992, 0xa})
        /home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/gauge.go:215 +0x1d
main.exporterQueue.Collect({0xc0000cd800, 0xc0000cca50, 0xc0000cd950, 0xc0000a0318, 0xc0000a0320}, {0xa00eb8, 0xc0004904e0}, 0x4669d3)
        /home/runner/work/rabbitmq_exporter/rabbitmq_exporter/exporter_queue.go:219 +0xf69
main.(*exporter).collectWithDuration(0xc000452c80, {0x9fe870, 0xc00044fef0}, {0xc000024029, 0x5}, 0x0)
        /home/runner/work/rabbitmq_exporter/rabbitmq_exporter/exporter.go:142 +0x394
main.(*exporter).Collect(0xc000452c80, 0xc00049e0c0)
        /home/runner/work/rabbitmq_exporter/rabbitmq_exporter/exporter.go:107 +0x23b
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
        /home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/registry.go:446 +0x102
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
        /home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/registry.go:538 +0xb4d
```