### PR TITLE
Update exporter_overview.go

### DIFF
--- a/exporter_overview.go
+++ b/exporter_overview.go
@@ -98,6 +98,7 @@ func (e *exporterOverview) Collect(ctx context.Context, ch chan<- prometheus.Met
 	for key, gauge := range e.overviewMetrics {
 		if value, ok := rabbitMqOverviewData[key]; ok {
 			log.WithFields(log.Fields{"key": key, "value": value}).Debug("Set overview metric for key")
+			gauge.Reset()
 			gauge.WithLabelValues(e.nodeInfo.ClusterName).Set(value)
 		}
 	}


### PR DESCRIPTION
reset overview gauge to remove previous data in case clustername change because of reset of cluster