### PR TITLE
chore: queue_state metric use 1 for running/idle, 0 for flow/etc

### DIFF
--- a/exporter_queue.go
+++ b/exporter_queue.go
@@ -97,7 +97,7 @@ func newExporterQueue() Exporter {
 		limitsGauge:         litmitsGaugeVecActual,
 		queueMetricsGauge:   queueGaugeVecActual,
 		queueMetricsCounter: queueCounterVecActual,
-		stateMetric:         newGaugeVec("queue_state", "A metric with a value of constant '1' if the queue is in a certain state", append(queueLabels, "state")),
+		stateMetric:         newGaugeVec("queue_state", "A metric with a value of queue state, 1(running,idle), 0(flow,blocked,unblocked)", append(queueLabels, "state")),
 		idleSinceMetric:     newGaugeVec("queue_idle_since_seconds", "starttime where the queue switched to idle state; in seconds since epoch (1970).", queueLabels),
 	}
 }
@@ -212,7 +212,14 @@ func (e exporterQueue) Collect(ctx context.Context, ch chan<- prometheus.Metric)
 				log.WithError(err).WithField("idle_since", idleSince).Warn("error parsing idle since time")
 			}
 		}
-		e.stateMetric.WithLabelValues(append(labelValues, state)...).Set(1)
+
+		switch state {
+		case "idle", "running":
+			e.stateMetric.WithLabelValues(append(labelValues, state)...).Set(1)
+		default:
+			// flow,blocked,unblocked
+			e.stateMetric.WithLabelValues(append(labelValues, state)...).Set(0)
+		}
 
 		if _, ok := limitsGaugeVec["max-length"]; ok {
 			if f := collectLowerMetric("arguments.x-max-length", "effective_policy_definition.max-length", queue); f >= 0 {

--- a/metrics.md
+++ b/metrics.md
@@ -59,7 +59,7 @@ metric | description
 |queue_max_length|How many (ready) messages a queue can contain before it starts to drop them from its head.|
 |queue_idle_since_seconds|starttime where the queue switched to idle state; seconds since epoch (1970); only set if queue state is idle|
 |queue_reductions_total|Number of reductions which take place on this process.|
-|queue_state|A metric with a value of constant '1' if the queue is in a certain state. Labels: vhost, queue, *state* (running, idle, flow,..)|
+|queue_state|A metric with a value of queue state, 1(running,idle), 0(flow,blocked,unblocked) Labels: vhost, queue, *state* (running, idle, flow,..)|
 |queue_slave_nodes_len|Number of slave nodes attached to the queue|
 |queue_synchronised_slave_nodes_len|Number of slave nodes in sync to the queue|
 


### PR DESCRIPTION
Modify the value of queue_state, with a value of 1 for running/idle, and 0 for flow and others.

Because we want 1 to represent a healthy state of the queue, and other numbers(0) to represent a crash.