### PR TITLE
add upstream, upstream_exchange, upstream_queue and uri labels

### DIFF
--- a/exporter_federation.go
+++ b/exporter_federation.go
@@ -11,8 +11,8 @@ func init() {
 }
 
 var (
-	federationLabels     = []string{"cluster", "vhost", "node", "queue", "exchange", "self", "status"}
-	federationLabelsKeys = []string{"vhost", "status", "node", "queue", "exchange"}
+	federationLabels     = []string{"cluster", "vhost", "node", "queue", "exchange", "self", "status", "upstream", "upstream_exchange", "upstream_queue", "uri"}
+	federationLabelsKeys = []string{"vhost", "status", "node", "queue", "exchange", "upstream", "upstream_exchange", "upstream_queue", "uri"}
 )
 
 type exporterFederation struct {
@@ -44,7 +44,7 @@ func (e exporterFederation) Collect(ctx context.Context, ch chan<- prometheus.Me
 
 	for _, federation := range federationData {
 		self := selfLabel(config, federation.labels["node"] == selfNode)
-		e.stateMetric.WithLabelValues(cluster, federation.labels["vhost"], federation.labels["node"], federation.labels["queue"], federation.labels["exchange"], self, federation.labels["status"]).Set(1)
+		e.stateMetric.WithLabelValues(cluster, federation.labels["vhost"], federation.labels["node"], federation.labels["queue"], federation.labels["exchange"], self, federation.labels["status"], federation.labels["upstream"], federation.labels["upstream_exchange"], federation.labels["upstream_queue"], federation.labels["uri"]).Set(1)
 	}
 
 	e.stateMetric.Collect(ch)

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -813,9 +813,9 @@ func TestFederation(t *testing.T) {
 		t.Log(strings.Join(reg.FindAllString(body, -1), "\n"))
 
 		expectSubstring(t, body, `rabbitmq_module_up{cluster="my-rabbit@ae74c041248b",module="federation",node="my-rabbit@ae74c041248b"} 1`)
-		expectSubstring(t, body, `rabbitmq_federation_state{cluster="my-rabbit@ae74c041248b",exchange="",node="my-rabbit@ae74c041248b",queue="test_queue1",self="1",status="running",vhost="/"} 1`)
-		expectSubstring(t, body, `rabbitmq_federation_state{cluster="my-rabbit@ae74c041248b",exchange="",node="rabbit@dc1rbmq1",queue="test_queue2",self="0",status="starting",vhost="/"} 1`)
-		expectSubstring(t, body, `rabbitmq_federation_state{cluster="my-rabbit@ae74c041248b",exchange="test_exchange1",node="rabbit@dc1rbmq1",queue="",self="0",status="running",vhost="/"} 1`)
+		expectSubstring(t, body, `rabbitmq_federation_state{cluster="my-rabbit@ae74c041248b",exchange="",node="my-rabbit@ae74c041248b",queue="test_queue1",self="1",status="running",upstream="root",upstream_exchange="",upstream_queue="test_queue1",uri="amqp://192.168.34.2",vhost="/"} 1`)
+		expectSubstring(t, body, `rabbitmq_federation_state{cluster="my-rabbit@ae74c041248b",exchange="",node="rabbit@dc1rbmq1",queue="test_queue2",self="0",status="starting",upstream="root",upstream_exchange="",upstream_queue="test_queue2",uri="amqp://192.168.34.2",vhost="/"} 1`)
+		expectSubstring(t, body, `rabbitmq_federation_state{cluster="my-rabbit@ae74c041248b",exchange="test_exchange1",node="rabbit@dc1rbmq1",queue="",self="0",status="running",upstream="root",upstream_exchange="test_exchange1",upstream_queue="",uri="amqp://192.168.34.2",vhost="/"} 1`)
 
 	})
 
@@ -831,9 +831,9 @@ func TestFederation(t *testing.T) {
 		t.Log(strings.Join(reg.FindAllString(body, -1), "\n"))
 
 		expectSubstring(t, body, `rabbitmq_module_up{cluster="my-rabbit@ae74c041248b",module="federation",node="my-rabbit@ae74c041248b"} 0`)
-		dontExpectSubstring(t, body, `rabbitmq_federation_state{cluster="my-rabbit@ae74c041248b",exchange="",node="my-rabbit@ae74c041248b",queue="test_queue1",self="0",status="running",vhost="/"} 1`)
-		dontExpectSubstring(t, body, `rabbitmq_federation_state{cluster="my-rabbit@ae74c041248b",exchange="",node="rabbit@dc1rbmq1",queue="test_queue2",self="0",status="starting",vhost="/"} 1`)
-		dontExpectSubstring(t, body, `rabbitmq_federation_state{cluster="my-rabbit@ae74c041248b",exchange="test_exchange1",node="rabbit@dc1rbmq1",queue="",self="0",status="running",vhost="/"} 1`)
+		dontExpectSubstring(t, body, `rabbitmq_federation_state{cluster="my-rabbit@ae74c041248b",exchange="",node="my-rabbit@ae74c041248b",queue="test_queue1",self="0",status="running",upstream="root",upstream_exchange="",upstream_queue="test_queue1",uri="amqp://192.168.34.2",vhost="/"} 1`)
+		dontExpectSubstring(t, body, `rabbitmq_federation_state{cluster="my-rabbit@ae74c041248b",exchange="",node="rabbit@dc1rbmq1",queue="test_queue2",self="0",status="starting",upstream="root",upstream_exchange="",upstream_queue="test_queue2",uri="amqp://192.168.34.2",vhost="/"} 1`)
+		dontExpectSubstring(t, body, `rabbitmq_federation_state{cluster="my-rabbit@ae74c041248b",exchange="test_exchange1",node="rabbit@dc1rbmq1",queue="",self="0",status="running",upstream="root",upstream_exchange="test_exchange1",upstream_queue="",uri="amqp://192.168.34.2",vhost="/"} 1`)
 
 	})
 


### PR DESCRIPTION
  Add missing labels to rabbitmq_federation_state metric to uniquely identify
  federation links. Without these labels, multiple federation links with the
  same exchange/vhost/node/status were being collapsed into a single metric.

  New labels:
  - upstream: federation upstream name (e.g., "fed.root")
  - upstream_exchange: exchange name on the upstream side
  - upstream_queue: queue name on the upstream side
  - uri: upstream connection URI (e.g., "amqps://rabbitmq-eu.example.com:5671/api")